### PR TITLE
use inspec's os_env split method

### DIFF
--- a/controls/6_2_user_and_group_settings.rb
+++ b/controls/6_2_user_and_group_settings.rb
@@ -111,7 +111,7 @@ control 'cis-dil-benchmark-6.2.6' do
   tag cis: 'distribution-independent-linux:6.2.6'
   tag level: 1
 
-  root_path = os_env('PATH').content.split(':')
+  root_path = os_env('PATH').split
 
   describe root_path do
     it { should_not be_empty }


### PR DESCRIPTION
Fixes #1 
This superseeds #2 and uses InSpec's internal split methods that ships with `os_env`

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>