### PR TITLE
changed command for redhat family to modprobe to properly evaluate test

### DIFF
--- a/libraries/linux_module.rb
+++ b/libraries/linux_module.rb
@@ -48,7 +48,7 @@ class LinuxModule < Inspec.resource(1)
 
   def version
     modinfo_cmd = if inspec.os.redhat? || inspec.os.name == 'fedora'
-                    "/sbin/modinfo -F version #{@module}"
+                    "/sbin/modinfo -F version #{@module} | awk '{$1=$1;print}'"
                   else
                     "modinfo -F version #{@module}"
                   end
@@ -59,7 +59,7 @@ class LinuxModule < Inspec.resource(1)
 
   def command
     modinfo_cmd = if inspec.os.redhat? || inspec.os.name == 'fedora'
-                    "/sbin/modprobe -n -v #{@module}"
+                    "/sbin/modprobe -n -v #{@module} | awk '{$1=$1;print}'"
                   else
                     "modinfo -n -v #{@module}"
                   end

--- a/libraries/linux_module.rb
+++ b/libraries/linux_module.rb
@@ -48,7 +48,7 @@ class LinuxModule < Inspec.resource(1)
 
   def version
     modinfo_cmd = if inspec.os.redhat? || inspec.os.name == 'fedora'
-                    "/sbin/modinfo -F version #{@module} | awk '{$1=$1;print}'"
+                    "/sbin/modinfo -F version #{@module}"
                   else
                     "modinfo -F version #{@module}"
                   end

--- a/libraries/linux_module.rb
+++ b/libraries/linux_module.rb
@@ -59,7 +59,7 @@ class LinuxModule < Inspec.resource(1)
 
   def command
     modinfo_cmd = if inspec.os.redhat? || inspec.os.name == 'fedora'
-                    "/sbin/modinfo -n -v #{@module}"
+                    "/sbin/modprobe -n -v #{@module}"
                   else
                     "modinfo -n -v #{@module}"
                   end

--- a/libraries/linux_module.rb
+++ b/libraries/linux_module.rb
@@ -58,11 +58,7 @@ class LinuxModule < Inspec.resource(1)
   end
 
   def command
-    modinfo_cmd = if inspec.os.redhat? || inspec.os.name == 'fedora'
-                    "/sbin/modprobe -n -v #{@module} | awk '{$1=$1;print}'"
-                  else
-                    "modinfo -n -v #{@module}"
-                  end
+    modinfo_cmd = "/sbin/modprobe -n -v #{@module} | awk '{$1=$1;print}'"
 
     cmd = inspec.command(modinfo_cmd)
     cmd.exit_status.zero? ? cmd.stdout.delete("\n") : nil


### PR DESCRIPTION
modinfo does not produce the correct output for the test and should use modprobe.  Test currently always fails when using modinfo due to output not matching.