### PR TITLE
On both Centos7 and latest Amazon Linux ansible auto creates cron ent…

### DIFF
--- a/controls/1_3_filesystem_integrity_checking.rb
+++ b/controls/1_3_filesystem_integrity_checking.rb
@@ -45,7 +45,7 @@ control 'cis-dil-benchmark-1.3.2' do
   tag level: 1
 
   describe.one do
-    %w(/var/spool/cron/crontabs/root /etc/crontab).each do |f|
+    %w(/var/spool/cron/crontabs/root /var/spool/cron/root /etc/crontab).each do |f|
       describe file(f) do
         its(:content) { should match(/aide --check/) }
       end

--- a/controls/1_3_filesystem_integrity_checking.rb
+++ b/controls/1_3_filesystem_integrity_checking.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 # author: Kristian Vlaardingerbroek
+#
 
 title '1.3 Filesystem Integrity Checking'
 


### PR DESCRIPTION
…ries at /var/spool/cron/root.