### PR TITLE
Ntpd run as user

### DIFF
--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -73,6 +73,10 @@ control 'cis-dil-benchmark-2.2.1.2' do
       its(:content) { should match(/^RUNASUSER=ntp\s*(?:#.*)?$/) }
     end
 
+    describe file('/etc/init.d/ntpd') do
+      its(:content) { should match(/^daemon "(?:.)?-u ntp:ntp\s*(?:.)?"\s*(?:#.*)?$/) }
+    end
+
     describe file('/etc/sysconfig/ntpd') do
       its(:content) { should match(/^OPTIONS="(?:.)?-u ntp:ntp\s*(?:.)?"\s*(?:#.*)?$/) }
     end

--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -74,7 +74,7 @@ control 'cis-dil-benchmark-2.2.1.2' do
     end
 
     describe file('/etc/init.d/ntpd') do
-      its(:content) { should match(/^daemon "(?:.)?-u ntp:ntp\s*(?:.)?"\s*(?:#.*)?$/) }
+      its(:content) { should match(/daemon\s+(\S+\s+)-u ntp:ntp(?:\s+|\s?")/) }
     end
 
     describe file('/etc/sysconfig/ntpd') do


### PR DESCRIPTION
Adding an additional option to check for existence of -u ntp:ntp, which is where it shows up on the latest Amazon Linux.