### PR TITLE
Allowed MACs should allow for greater security

### DIFF
--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -187,7 +187,7 @@ control 'cis-dil-benchmark-5.2.12' do
   end
 
   ALLOWED_MACS = [
-    'mac-sha2-512-etm@openssh.com',
+    'hmac-sha2-512-etm@openssh.com',
     'hmac-sha2-256-etm@openssh.com',
     'umac-128-etm@openssh.com',
     'hmac-sha2-512',

--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -188,7 +188,7 @@ control 'cis-dil-benchmark-5.2.12' do
 
   if sshd_config.MACs
     describe sshd_config.MACs.split(',').each do
-      it { should match(/^((hmac-sha2-512-etm@openssh\.com|hmac-sha2-256-etm@openssh\.com|umac-128-etm@openssh\.com|hmac-sha2-512|hmac-sha2-256|umac-128@openssh\.com|curve25519-sha256@libssh\.org|diffie-hellman-group-exchange-sha256),)*(hmac-sha2-512-etm@openssh\.com|hmac-sha2-256-etm@openssh\.com|umac-128-etm@openssh\.com|hmac-sha2-512|hmac-sha2-256|umac-128@openssh\.com)$/) }
+      it { should be_in(/^((hmac-sha2-512-etm@openssh\.com|hmac-sha2-256-etm@openssh\.com|umac-128-etm@openssh\.com|hmac-sha2-512|hmac-sha2-256|umac-128@openssh\.com|curve25519-sha256@libssh\.org|diffie-hellman-group-exchange-sha256),)*(hmac-sha2-512-etm@openssh\.com|hmac-sha2-256-etm@openssh\.com|umac-128-etm@openssh\.com|hmac-sha2-512|hmac-sha2-256|umac-128@openssh\.com)$/) }
     end
   end
 end

--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -186,9 +186,20 @@ control 'cis-dil-benchmark-5.2.12' do
     its(:MACs) { should_not be_nil }
   end
 
+  ALLOWED_MACS = [
+    'mac-sha2-512-etm@openssh.com',
+    'hmac-sha2-256-etm@openssh.com',
+    'umac-128-etm@openssh.com',
+    'hmac-sha2-512',
+    'hmac-sha2-256',
+    'umac-128@openssh.com',
+    'curve25519-sha256@libssh.org',
+    'diffie-hellman-group-exchange-sha256'
+  ]
+
   if sshd_config.MACs
     describe sshd_config.MACs.split(',').each do
-      it { should be_in(/^((hmac-sha2-512-etm@openssh\.com|hmac-sha2-256-etm@openssh\.com|umac-128-etm@openssh\.com|hmac-sha2-512|hmac-sha2-256|umac-128@openssh\.com|curve25519-sha256@libssh\.org|diffie-hellman-group-exchange-sha256),)*(hmac-sha2-512-etm@openssh\.com|hmac-sha2-256-etm@openssh\.com|umac-128-etm@openssh\.com|hmac-sha2-512|hmac-sha2-256|umac-128@openssh\.com)$/) }
+      it { should be_in ALLOWED_MACS }
     end
   end
 end

--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -198,8 +198,10 @@ control 'cis-dil-benchmark-5.2.12' do
   ]
 
   if sshd_config.MACs
-    describe sshd_config.MACs.split(',').each do
-      it { should be_in ALLOWED_MACS }
+    sshd_config.MACs.split(',').each do |m|
+      describe m do
+        it { should be_in ALLOWED_MACS }
+      end
     end
   end
 end

--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -195,7 +195,7 @@ control 'cis-dil-benchmark-5.2.12' do
     'umac-128@openssh.com',
     'curve25519-sha256@libssh.org',
     'diffie-hellman-group-exchange-sha256'
-  ]
+  ].freeze
 
   if sshd_config.MACs
     sshd_config.MACs.split(',').each do |m|


### PR DESCRIPTION
The current match scheme does not allow for greater security, this check will ensure that each MAC is in the allowed list instead.