### PR TITLE
1 1 redhat

### DIFF
--- a/controls/1_1_filesystem_configuration.rb
+++ b/controls/1_1_filesystem_configuration.rb
@@ -144,13 +144,20 @@ control 'cis-dil-benchmark-1.1.1.8' do
   tag cis: 'distribution-independent-linux:1.1.1.8'
   tag level: 1
 
-  describe linux_module('vfat') do
-    it { should_not be_loaded }
-    its(:command) { should match(%r{^install /bin/trueinstall /bin/true$}) }
-  end
-  describe linux_module('msdos') do
-    it { should_not be_loaded }
-    its(:command) { should match(%r{^install /bin/trueinstall /bin/true$}) }
+  if os.family == 'redhat' then
+    describe linux_module('vfat') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^install /bin/trueinstall /bin/true$}) }
+    end
+    describe linux_module('msdos') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^install /bin/trueinstall /bin/true$}) }
+    end
+  else
+    describe linux_module('vfat') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^install /bin/true$}) }
+    end
   end
 end
 

--- a/controls/1_1_filesystem_configuration.rb
+++ b/controls/1_1_filesystem_configuration.rb
@@ -56,6 +56,7 @@ control 'cis-dil-benchmark-1.1.1.3' do
   tag level: 1
 
   if os.redhat? && os.release.to_i < 7 then
+    # redhat < 7 depends on zlib_deflate.ko
     describe linux_module('jffs2') do
       it { should_not be_loaded }
       its(:command) { should match(%r{^insmod.*zlib_deflate.koinstall /bin/true$}) }
@@ -119,11 +120,13 @@ control 'cis-dil-benchmark-1.1.1.7' do
   tag level: 1
 
   if os.redhat? && os.release.to_i < 7 then
+    # redhat < 7 depends on the crc-itu-t.ko module
     describe linux_module('udf') do
       it { should_not be_loaded }
       its(:command) { should match(%r{^insmod.*crc-itu-t.koinstall /bin/true$}) }
     end
   elsif os.family == 'redhat' then
+    # redhat family depends on the crc-itu-t.ko.xz module
     describe linux_module('udf') do
       it { should_not be_loaded }
       its(:command) { should match(%r{^insmod.*crc-itu-t.ko.xzinstall /bin/true$}) }
@@ -145,6 +148,7 @@ control 'cis-dil-benchmark-1.1.1.8' do
   tag level: 1
 
   if os.family == 'redhat' then
+    # redhat family loads 2 modules vfat and msdos and will show both modules when checking
     describe linux_module('vfat') do
       it { should_not be_loaded }
       its(:command) { should match(%r{^install /bin/trueinstall /bin/true$}) }

--- a/controls/1_1_filesystem_configuration.rb
+++ b/controls/1_1_filesystem_configuration.rb
@@ -123,7 +123,7 @@ control 'cis-dil-benchmark-1.1.1.7' do
       it { should_not be_loaded }
       its(:command) { should match(%r{^insmod.*crc-itu-t.koinstall /bin/true$}) }
     end
-  elsif os.family? == 'redhat' then
+  elsif os.family == 'redhat' then
     describe linux_module('udf') do
       it { should_not be_loaded }
       its(:command) { should match(%r{^insmod.*crc-itu-t.ko.xzinstall /bin/true$}) }

--- a/controls/1_1_filesystem_configuration.rb
+++ b/controls/1_1_filesystem_configuration.rb
@@ -55,9 +55,16 @@ control 'cis-dil-benchmark-1.1.1.3' do
   tag cis: 'distribution-independent-linux:1.1.1.3'
   tag level: 1
 
-  describe linux_module('jffs2') do
-    it { should_not be_loaded }
-    its(:command) { should match(%r{^install /bin/true$}) }
+  if os.redhat? && os.release.to_i < 7 then
+    describe linux_module('jffs2') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^insmod.*zlib_deflate.koinstall /bin/true$}) }
+    end
+  else
+    describe linux_module('jffs2') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^install /bin/true$}) }
+    end
   end
 end
 
@@ -111,9 +118,21 @@ control 'cis-dil-benchmark-1.1.1.7' do
   tag cis: 'distribution-independent-linux:1.1.1.7'
   tag level: 1
 
-  describe linux_module('udf') do
-    it { should_not be_loaded }
-    its(:command) { should match(%r{^install /bin/true$}) }
+  if os.redhat? && os.release.to_i < 7 then
+    describe linux_module('udf') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^insmod.*crc-itu-t.koinstall /bin/true$}) }
+    end
+  elsif os.family? == 'redhat' then
+    describe linux_module('udf') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^insmod.*crc-itu-t.ko.xzinstall /bin/true$}) }
+    end
+  else
+    describe linux_module('udf') do
+      it { should_not be_loaded }
+      its(:command) { should match(%r{^install /bin/true$}) }
+    end
   end
 end
 
@@ -127,7 +146,11 @@ control 'cis-dil-benchmark-1.1.1.8' do
 
   describe linux_module('vfat') do
     it { should_not be_loaded }
-    its(:command) { should match(%r{^install /bin/true$}) }
+    its(:command) { should match(%r{^install /bin/trueinstall /bin/true$}) }
+  end
+  describe linux_module('msdos') do
+    it { should_not be_loaded }
+    its(:command) { should match(%r{^install /bin/trueinstall /bin/true$}) }
   end
 end
 


### PR DESCRIPTION
The changes allow for inspec to pass when run against centos 6/7 and rhel 6/7
redhat < 7 has some specific differences required to be accounted for
redhat family has several kernel modules that load multiple modules for dependencies and show up in the modprobe information and need to be accounted for