### PR TITLE
Adjust modprobe check to remove false positives.

### DIFF
--- a/libraries/linux_module.rb
+++ b/libraries/linux_module.rb
@@ -58,7 +58,9 @@ class LinuxModule < Inspec.resource(1)
   end
 
   def command
-    modinfo_cmd = "/sbin/modprobe -n -v #{@module} | awk '{$1=$1;print}'"
+    # Lets just ensure the last line in the kernel module's configuration is 'install /bin/true'
+    # this is enough to be sure the module will not be loaded on next reboot or run of modprobe
+    modinfo_cmd = "/sbin/modprobe -n -v #{@module} | tail -n 1 | awk '{$1=$1;print}'"
 
     cmd = inspec.command(modinfo_cmd)
     cmd.exit_status.zero? ? cmd.stdout.delete("\n") : nil


### PR DESCRIPTION
The current check will mark the below a failure:
```
insmod /lib/modules/4.9.43-17.39.amzn1.x86_64/kernel/net/ipv4/udp_tunnel.ko
insmod /lib/modules/4.9.43-17.39.amzn1.x86_64/kernel/net/ipv6/ip6_udp_tunnel.ko
install /bin/true
```
even though 'install /bin/true' is the last entry in the file, which would properly enforce the removal of the kernel module.