### PR TITLE
Allow for Debian's usage of group 'shadow' with id 42.

### DIFF
--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -90,7 +90,11 @@ control 'cis-dil-benchmark-6.1.3' do
       it { should_not be_writable.by 'other' }
       it { should_not be_executable.by 'other' }
       its(:uid) { should cmp 0 }
-      its(:gid) { should cmp 0 }
+      if os.debian?
+        its(:gid) { should cmp 42 }
+      else
+        its(:gid) { should cmp 0 }
+      end
       its(:sticky) { should equal false }
       its(:suid) { should equal false }
       its(:sgid) { should equal false }
@@ -154,7 +158,11 @@ control 'cis-dil-benchmark-6.1.5' do
       it { should_not be_writable.by 'other' }
       it { should_not be_executable.by 'other' }
       its(:uid) { should cmp 0 }
-      its(:gid) { should cmp 0 }
+      if os.debian?
+        its(:gid) { should cmp 42 }
+      else
+        its(:gid) { should cmp 0 }
+      end
       its(:sticky) { should equal false }
       its(:suid) { should equal false }
       its(:sgid) { should equal false }


### PR DESCRIPTION
Fixes #31 