### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/controls/1_4_secure_boot_settings.rb
+++ b/controls/1_4_secure_boot_settings.rb
@@ -69,7 +69,7 @@ control 'cis-dil-benchmark-1.4.3' do
   tag level: 1
 
   describe.one do
-    describe shadow.users('root') do
+    describe shadow.user('root') do
       its(:password) { should_not include('*') }
       its(:password) { should_not include('!') }
     end

--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -82,7 +82,7 @@ control 'cis-dil-benchmark-5.4.1.3' do
   end
 
   shadow_files.each do |f|
-    shadow(f).users(/.+/).entries.each do |user|
+    shadow(f).user(/.+/).entries.each do |user|
       next if (user.password && %w(* !)).any?
 
       describe user do
@@ -105,7 +105,7 @@ control 'cis-dil-benchmark-5.4.1.4' do
   end
 
   shadow_files.each do |f|
-    shadow(f).users(/.+/).entries.each do |user|
+    shadow(f).user(/.+/).entries.each do |user|
       next if (user.password && %w(* !)).any?
 
       describe user do


### PR DESCRIPTION
This PR fixes some deprecation warnings regarding `shadow(f).users` being deprecated in inspec 3.0.0.