### PR TITLE
Make the check slightly less strict.

### DIFF
--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -199,6 +199,6 @@ control 'cis-dil-benchmark-5.6' do
   tag level: 1
 
   describe file('/etc/pam.d/su') do
-    its(:content) { should match(/^auth required pam_wheel.so use_uid$/) }
+    its(:content) { should match(/^auth\s+required\s+pam_wheel.so use_uid$/) }
   end
 end


### PR DESCRIPTION
This allows it to recognise strings in pam files on Debian, as Debian prefers lots of whitespace between some elements.