### PR TITLE
This fixes for the syntax for CIS DIL 4.1.6 to require just one valid describe.

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -152,7 +152,13 @@ if cis_level == '2'
     describe.one do
       describe file('/etc/audit/audit.rules') do
         its(:content) { should match(%r{^-w /etc/network -p wa -k system-locale$}) }
+      end
+
+      describe file('/etc/audit/audit.rules') do
         its(:content) { should match(%r{^-w /etc/networks -p wa -k system-locale$}) }
+      end
+
+      describe file('/etc/audit/audit.rules') do
         its(:content) { should match(%r{^-w /etc/sysconfig/network -p wa -k system-locale$}) }
       end
     end


### PR DESCRIPTION
I think this is how it was meant to be, as I doubt a system has all three of /etc/sysconfig/network, /etc/network and /etc/networks.