### PR TITLE
According to CIS DIL 1.1.0, wtmp and btmp should be tagged logins.

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -208,8 +208,8 @@ if cis_level == '2'
 
     describe file('/etc/audit/audit.rules') do
       its(:content) { should match(%r{^-w /var/run/utmp -p wa -k session$}) }
-      its(:content) { should match(%r{^-w /var/log/wtmp -p wa -k session$}) }
-      its(:content) { should match(%r{^-w /var/log/btmp -p wa -k session$}) }
+      its(:content) { should match(%r{^-w /var/log/wtmp -p wa -k logins$}) }
+      its(:content) { should match(%r{^-w /var/log/btmp -p wa -k logins$}) }
     end
   end
 


### PR DESCRIPTION
... And not with sessions, as this check currently tests.