### PR TITLE
Make the 4.1.15 check less strict.

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -320,7 +320,7 @@ if cis_level == '2'
 
     describe file('/etc/audit/audit.rules') do
       its(:content) { should match(%r{^-w /etc/sudoers -p wa -k scope$}) }
-      its(:content) { should match(%r{^-w /etc/sudoers\.d -p wa -k scope$}) }
+      its(:content) { should match(%r{^-w /etc/sudoers\.d/? -p wa -k scope$}) }
     end
   end
 


### PR DESCRIPTION
The check currently checks for /etc/sudoers.d without and ending slash, but the CIS DIL Benchmark 1.1.0 document says it requires an ending slash. This change will allow both, as the actual slash has little effect on the effectiveness of the check.