### PR TITLE
Also allow pool to be set.

### DIFF
--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -56,8 +56,14 @@ control 'cis-dil-benchmark-2.2.1.2' do
     package('ntp').installed? || command('ntpd').exist?
   end
 
-  describe ntp_conf do
-    its(:server) { should_not eq nil }
+  describe.one do
+    describe ntp_conf do
+      its(:server) { should_not eq nil }
+    end
+
+    describe ntp_conf do
+      its(:pool) { should_not eq nil }
+    end
   end
 
   describe ntp_conf.restrict.to_s do


### PR DESCRIPTION
As Debian uses pool instead of server, this makes the check succeed. The
CIS DIL Benchmark 1.1.0 actually states that it also allows pool to be
set instead of server.