### PR TITLE
Fix a compare with zero.

### DIFF
--- a/controls/1_6_mandatory_access_control.rb
+++ b/controls/1_6_mandatory_access_control.rb
@@ -185,7 +185,7 @@ if cis_level == '2'
     end
 
     describe command('apparmor_status --complaining') do
-      its(:stdout) { should cmp.zero? }
+      its(:stdout) { should cmp 0 }
     end
 
     describe command('apparmor_status') do


### PR DESCRIPTION
My version of inspec does not support `cmp.zero?` and I cannot find any reference to it in the code. Just doing `cmp 0` seems to do what's intended.