### PR TITLE
handle potential leading space for umask regex

### DIFF
--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -163,7 +163,7 @@ control 'cis-dil-benchmark-5.4.4' do
 
   %w(bash.bashrc profile bashrc).each do |f|
     describe file("/etc/#{f}") do
-      its(:content) { should_not match(/^umask [01234567](0[7654321]|[7654321][654321])\s*(?:#.*)?$/) }
+      its(:content) { should_not match(/^\s*umask [01234567](0[7654321]|[7654321][654321])\s*(?:#.*)?$/) }
     end
   end
 
@@ -171,7 +171,7 @@ control 'cis-dil-benchmark-5.4.4' do
     %w(bash.bashrc profile bashrc).each do |f|
       next unless file("/etc/#{f}").file?
       describe file("/etc/#{f}") do
-        its(:content) { should match(/^umask [01234567][2367]7\s*(?:#.*)?$/) }
+        its(:content) { should match(/^\s*umask [01234567][2367]7\s*(?:#.*)?$/) }
       end
     end
   end


### PR DESCRIPTION
For example, the default `/etc/profile` on CentOS 7 has code that looks like this:

```
if [ $UID -gt 199 ] && [ \"`/usr/bin/id -gn`\" = \"`/usr/bin/id -un`\" ]; then
    umask 027
else
    umask 022
fi
```