### PR TITLE
modify package check to satisfy openjdk dependency

### DIFF
--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -130,7 +130,7 @@ control 'cis-dil-benchmark-2.2.2' do
     its(:names) { should be_empty }
   end
 
-  describe packages(/^xorg-x11.*/) do
+  describe packages(/^xorg-x11-server.*/) do
     its(:names) { should be_empty }
   end
 end


### PR DESCRIPTION
The check as currently constituted invalidates an opendjk dependency, `xorg-x11-fonts-Type1`; Cf.
- https://bugzilla.redhat.com/show_bug.cgi?id=999287
- https://bugzilla.redhat.com/show_bug.cgi?id=721033
- https://centos.pkgs.org/7/centos-x86_64/java-1.8.0-openjdk-1.8.0.161-2.b14.el7.i686.rpm.html
- https://centos.pkgs.org/7/centos-x86_64/java-1.7.0-openjdk-1.7.0.171-2.6.13.2.el7.x86_64.rpm.html
- https://centos.pkgs.org/6/centos-x86_64/java-1.7.0-openjdk-1.7.0.181-2.6.14.10.el6.x86_64.rpm.html

A list of packages that would still be checked (on `CentOS Linux release 7.5.1804 (Core)`):
```
xorg-x11-server-Xdmx.x86_64 : Distributed Multihead X Server and utilities
xorg-x11-server-Xephyr.x86_64 : A nested server.
xorg-x11-server-Xnest.x86_64 : A nested server.
xorg-x11-server-Xorg.x86_64 : Xorg X server
xorg-x11-server-Xspice.x86_64 : XSpice is an X server that can be accessed by a Spice client
xorg-x11-server-Xvfb.x86_64 : A X Windows System virtual framebuffer X server.
xorg-x11-server-Xwayland.x86_64 : Wayland X Server
xorg-x11-server-common.x86_64 : Xorg server common files
xorg-x11-server-devel.i686 : SDK for X server driver module development
xorg-x11-server-devel.x86_64 : SDK for X server driver module development
xorg-x11-server-source.noarch : Xserver source code required to build VNC server (Xvnc)
xorg-x11-server-utils.x86_64 : X.Org X11 X server utilities
```
These will now be allowed:
```
xorg-x11-apps.x86_64 : X.Org X11 applications
xorg-x11-docs.noarch : X.Org X11 documentation
xorg-x11-drivers.x86_64 : X.Org X11 driver installation package
xorg-x11-drv-ati.x86_64 : Xorg X11 ati video driver
xorg-x11-drv-dummy.x86_64 : Xorg X11 dummy video driver
xorg-x11-drv-evdev.x86_64 : Xorg X11 evdev input driver
xorg-x11-drv-evdev-devel.i686 : Xorg X11 evdev input driver development package.
xorg-x11-drv-evdev-devel.x86_64 : Xorg X11 evdev input driver development package.
xorg-x11-drv-fbdev.x86_64 : Xorg X11 fbdev video driver
xorg-x11-drv-intel.i686 : Xorg X11 Intel video driver
xorg-x11-drv-intel.x86_64 : Xorg X11 Intel video driver
xorg-x11-drv-intel-devel.i686 : Xorg X11 Intel video driver development package
xorg-x11-drv-intel-devel.x86_64 : Xorg X11 Intel video driver development package
xorg-x11-drv-keyboard.x86_64 : Xorg X11 keyboard input driver
xorg-x11-drv-libinput.x86_64 : Xorg X11 libinput input driver
xorg-x11-drv-libinput-devel.i686 : Xorg X11 libinput input driver development package.
xorg-x11-drv-libinput-devel.x86_64 : Xorg X11 libinput input driver development package.
xorg-x11-drv-mouse.x86_64 : Xorg X11 mouse input driver
xorg-x11-drv-mouse-devel.i686 : Xorg X11 mouse input driver development package.
xorg-x11-drv-mouse-devel.x86_64 : Xorg X11 mouse input driver development package.
xorg-x11-drv-nouveau.x86_64 : Xorg X11 nouveau video driver for NVIDIA graphics chipsets
xorg-x11-drv-openchrome.i686 : Xorg X11 openchrome video driver
xorg-x11-drv-openchrome.x86_64 : Xorg X11 openchrome video driver
xorg-x11-drv-openchrome-devel.i686 : Xorg X11 openchrome video driver XvMC development package
xorg-x11-drv-openchrome-devel.x86_64 : Xorg X11 openchrome video driver XvMC development package
xorg-x11-drv-qxl.x86_64 : Xorg X11 qxl video driver
xorg-x11-drv-synaptics.x86_64 : Xorg X11 Synaptics touchpad input driver
xorg-x11-drv-synaptics-devel.i686 : Xorg X11 synaptics input driver
xorg-x11-drv-synaptics-devel.x86_64 : Xorg X11 synaptics input driver
xorg-x11-drv-v4l.x86_64 : Xorg X11 v4l video driver
xorg-x11-drv-vesa.x86_64 : Xorg X11 vesa video driver
xorg-x11-drv-vmmouse.x86_64 : Xorg X11 vmmouse input driver
xorg-x11-drv-vmware.x86_64 : Xorg X11 vmware video driver
xorg-x11-drv-void.x86_64 : Xorg X11 void input driver
xorg-x11-drv-wacom.x86_64 : Xorg X11 wacom input driver
xorg-x11-drv-wacom-devel.i686 : Xorg X11 wacom input driver development package
xorg-x11-drv-wacom-devel.x86_64 : Xorg X11 wacom input driver development package
xorg-x11-font-utils.x86_64 : X.Org X11 font utilities
xorg-x11-fonts-100dpi.noarch : A set of 100dpi resolution fonts for the X Window System.
xorg-x11-fonts-75dpi.noarch : A set of 75dpi resolution fonts for the X Window System.
xorg-x11-fonts-ISO8859-1-100dpi.noarch : A set of 100dpi ISO-8859-1 fonts for X.
xorg-x11-fonts-ISO8859-1-75dpi.noarch : A set of 75dpi ISO-8859-1 fonts for X.
xorg-x11-fonts-ISO8859-14-100dpi.noarch : ISO8859-14-100dpi fonts
xorg-x11-fonts-ISO8859-14-75dpi.noarch : ISO8859-14-75dpi fonts
xorg-x11-fonts-ISO8859-15-100dpi.noarch : ISO8859-15-100dpi fonts
xorg-x11-fonts-ISO8859-15-75dpi.noarch : ISO8859-15-75dpi fonts
xorg-x11-fonts-ISO8859-2-100dpi.noarch : A set of 100dpi Central European language fonts for X.
xorg-x11-fonts-ISO8859-2-75dpi.noarch : A set of 75dpi Central European language fonts for X.
xorg-x11-fonts-ISO8859-9-100dpi.noarch : ISO8859-9-100dpi fonts
xorg-x11-fonts-ISO8859-9-75dpi.noarch : ISO8859-9-75dpi fonts
xorg-x11-fonts-Type1.noarch : Type1 fonts provided by the X Window System
xorg-x11-fonts-cyrillic.noarch : Cyrillic fonts for X.
xorg-x11-fonts-ethiopic.noarch : Ethiopic fonts
xorg-x11-fonts-misc.noarch : misc bitmap fonts for the X Window System
xorg-x11-proto-devel.noarch : X.Org X11 Protocol headers
xorg-x11-resutils.x86_64 : X.Org X11 X resource utilities
xorg-x11-util-macros.noarch : X.Org X11 Autotools macros
xorg-x11-utils.x86_64 : X.Org X11 X client utilities
xorg-x11-xauth.x86_64 : X.Org X11 X authority utilities
xorg-x11-xbitmaps.noarch : X.Org X11 application bitmaps
xorg-x11-xinit.x86_64 : X.Org X11 X Window System xinit startup scripts
xorg-x11-xinit-session.x86_64 : Display manager support for ~/.xsession and ~/.Xclients
xorg-x11-xkb-extras.x86_64 : X.Org X11 xkb gadgets
xorg-x11-xkb-utils.x86_64 : X.Org X11 xkb utilities
xorg-x11-xkb-utils-devel.i686 : X.Org X11 xkb utilities development package
xorg-x11-xkb-utils-devel.x86_64 : X.Org X11 xkb utilities development package
xorg-x11-xtrans-devel.noarch : X.Org X11 developmental X transport library
```