### PR TITLE
Correct passwd- check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CIS Distribution Independent Linux Benchmark - InSpec Profile
 
 ## Description
-This profile implements the [CIS Distribution Independent Linux 1.0.1 Benchmark](https://www.cisecurity.org/benchmark/distribution_independent_linux/).
+This profile implements the [CIS Distribution Independent Linux 1.1.0 Benchmark](https://www.cisecurity.org/benchmark/distribution_independent_linux/).
 
 ## Attributes
 

--- a/controls/1_1_filesystem_configuration.rb
+++ b/controls/1_1_filesystem_configuration.rb
@@ -251,12 +251,65 @@ control 'cis-dil-benchmark-1.1.10' do
 end
 
 control 'cis-dil-benchmark-1.1.11' do
-  title 'Ensure separate partition exists for /var/log'
-  desc  "The /var/log directory is used by system services to store log data .\n\nRationale: There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
+  title 'Ensure noexec option set on /var/tmp partition'
+  desc  "The noexec mount option specifies that the filesystem cannot contain executable binaries.\n\nRationale: Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
   impact 1.0
 
   tag cis: 'distribution-independent-linux:1.1.11'
-  tag level: 2
+  tag level: 1
+
+  describe mount('/var/tmp') do
+    its(:options) { should include 'noexec' }
+  end
+end
+
+control 'cis-dil-benchmark-1.1.12' do
+  title 'Ensure noexec option set on /var/tmp partition'
+  desc  "The noexec mount option specifies that the filesystem cannot contain executable binaries.\n\nRationale: Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+  impact 1.0
+
+  tag cis: 'distribution-independent-linux:1.1.12'
+  tag level: 1
+
+  describe mount('/var/tmp') do
+    its(:options) { should include 'noexec' }
+  end
+end
+
+control 'cis-dil-benchmark-1.1.13' do
+  title 'Ensure noexec option set on /var/tmp partition'
+  desc  "The noexec mount option specifies that the filesystem cannot contain executable binaries.\n\nRationale: Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+  impact 1.0
+
+  tag cis: 'distribution-independent-linux:1.1.13'
+  tag level: 1
+
+  describe mount('/var/tmp') do
+    its(:options) { should include 'noexec' }
+  end
+end
+
+control 'cis-dil-benchmark-1.1.14' do
+  title 'Ensure noexec option set on /var/tmp partition'
+  desc  "The noexec mount option specifies that the filesystem cannot contain executable binaries.\n\nRationale: Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+  impact 1.0
+
+  tag cis: 'distribution-independent-linux:1.1.14'
+  tag level: 1
+
+  describe mount('/var/tmp') do
+    its(:options) { should include 'noexec' }
+  end
+end
+
+if cis_level == '2'
+  control 'cis-dil-benchmark-1.1.15' do
+    title 'Ensure separate partition exists for /var/log'
+    desc  "The /var/log directory is used by system services to store log data .\n\nRationale: There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data."
+    impact 1.0
+
+    tag cis: 'distribution-independent-linux:1.1.15'
+    tag level: 2
 
   describe mount('/var/log') do
     it { should be_mounted }
@@ -264,13 +317,13 @@ control 'cis-dil-benchmark-1.1.11' do
   only_if { cis_level == 2 }
 end
 
-control 'cis-dil-benchmark-1.1.12' do
-  title 'Ensure separate partition exists for /var/log/audit'
-  desc  "The auditing daemon, auditd, stores log data in the /var/log/audit directory.\n\nRationale: There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd, it may not perform as desired."
-  impact 1.0
+  control 'cis-dil-benchmark-1.1.16' do
+    title 'Ensure separate partition exists for /var/log/audit'
+    desc  "The auditing daemon, auditd, stores log data in the /var/log/audit directory.\n\nRationale: There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd, it may not perform as desired."
+    impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.12'
-  tag level: 2
+    tag cis: 'distribution-independent-linux:1.1.16'
+    tag level: 2
 
   only_if { cis_level == 2 }
 
@@ -279,13 +332,13 @@ control 'cis-dil-benchmark-1.1.12' do
   end
 end
 
-control 'cis-dil-benchmark-1.1.13' do
-  title 'Ensure separate partition exists for /home'
-  desc  "The /home directory is used to support disk storage needs of local users.\n\nRationale: If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
-  impact 1.0
+  control 'cis-dil-benchmark-1.1.17' do
+    title 'Ensure separate partition exists for /home'
+    desc  "The /home directory is used to support disk storage needs of local users.\n\nRationale: If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
+    impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.13'
-  tag level: 2
+    tag cis: 'distribution-independent-linux:1.1.17'
+    tag level: 2
 
   only_if { cis_level == 2 }
 
@@ -294,12 +347,12 @@ control 'cis-dil-benchmark-1.1.13' do
   end
 end
 
-control 'cis-dil-benchmark-1.1.14' do
+control 'cis-dil-benchmark-1.1.18' do
   title 'Ensure nodev option set on /home partition'
   desc  "The nodev mount option specifies that the filesystem cannot contain special devices.\n\nRationale: Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
   impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.14'
+  tag cis: 'distribution-independent-linux:1.1.18'
   tag level: 1
 
   describe mount('/home') do
@@ -307,12 +360,12 @@ control 'cis-dil-benchmark-1.1.14' do
   end
 end
 
-control 'cis-dil-benchmark-1.1.15' do
+control 'cis-dil-benchmark-1.1.19' do
   title 'Ensure nodev option set on /dev/shm partition'
   desc  "The nodev mount option specifies that the filesystem cannot contain special devices.\n\nRationale: Since the /run/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
   impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.15'
+  tag cis: 'distribution-independent-linux:1.1.19'
   tag level: 1
 
   describe mount('/dev/shm') do
@@ -320,12 +373,12 @@ control 'cis-dil-benchmark-1.1.15' do
   end
 end
 
-control 'cis-dil-benchmark-1.1.16' do
+control 'cis-dil-benchmark-1.1.20' do
   title 'Ensure nosuid option set on /dev/shm partitionrun'
   desc  "The nosuid mount option specifies that the filesystem cannot contain setuid files.\n\nRationale: Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
   impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.16'
+  tag cis: 'distribution-independent-linux:1.1.20'
   tag level: 1
 
   describe mount('/dev/shm') do
@@ -333,12 +386,12 @@ control 'cis-dil-benchmark-1.1.16' do
   end
 end
 
-control 'cis-dil-benchmark-1.1.17' do
+control 'cis-dil-benchmark-1.1.21' do
   title 'Ensure noexec option set on /dev/shm partition'
   desc  "The noexec mount option specifies that the filesystem cannot contain executable binaries.\n\nRationale: Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
   impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.17'
+  tag cis: 'distribution-independent-linux:1.1.21'
   tag level: 1
 
   describe mount('/dev/shm') do
@@ -346,51 +399,51 @@ control 'cis-dil-benchmark-1.1.17' do
   end
 end
 
-control 'cis-dil-benchmark-1.1.18' do
+control 'cis-dil-benchmark-1.1.22' do
   title 'Ensure nodev option set on removable media partitions'
   desc  "The nodev mount option specifies that the filesystem cannot contain special devices.\n\nRationale: Removable media containing character and block special devices could be used to circumvent security controls by allowing non-root users to access sensitive device files such as /dev/kmem or the raw disk partitions."
   impact 0.0
 
-  tag cis: 'distribution-independent-linux:1.1.18'
+  tag cis: 'distribution-independent-linux:1.1.22'
   tag level: 1
 
-  describe 'cis-dil-benchmark-1.1.18' do
+  describe 'cis-dil-benchmark-1.1.22' do
     skip 'Not implemented'
   end
 end
 
-control 'cis-dil-benchmark-1.1.19' do
+control 'cis-dil-benchmark-1.1.23' do
   title 'Ensure nosuid option set on removable media partitions'
   desc  "The nosuid mount option specifies that the filesystem cannot contain setuid files.\n\nRationale: Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
   impact 0.0
 
-  tag cis: 'distribution-independent-linux:1.1.19'
+  tag cis: 'distribution-independent-linux:1.1.23'
   tag level: 1
 
-  describe 'cis-dil-benchmark-1.1.19' do
+  describe 'cis-dil-benchmark-1.1.23' do
     skip 'Not implemented'
   end
 end
 
-control 'cis-dil-benchmark-1.1.20' do
+control 'cis-dil-benchmark-1.1.24' do
   title 'Ensure noexec option set on removable media partitions'
   desc  "The noexec mount option specifies that the filesystem cannot contain executable binaries.\n\nRationale: Setting this option on a file system prevents users from executing programs from the removable media. This deters users from being able to introduce potentially malicious software on the system."
   impact 0.0
 
-  tag cis: 'distribution-independent-linux:1.1.20'
+  tag cis: 'distribution-independent-linux:1.1.24'
   tag level: 1
 
-  describe 'cis-dil-benchmark-1.1.20' do
+  describe 'cis-dil-benchmark-1.1.24' do
     skip 'Not implemented'
   end
 end
 
-control 'cis-dil-benchmark-1.1.21' do
+control 'cis-dil-benchmark-1.1.25' do
   title 'Ensure sticky bit is set on all world-writable directories'
   desc  "Setting the sticky bit on world writable directories prevents users from deleting or renaming files in that directory that are not owned by them.\n\nRationale: This feature prevents the ability to delete or rename files in world writable directories (such as /tmp) that are owned by another user."
   impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.21'
+  tag cis: 'distribution-independent-linux:1.1.25'
   tag level: 1
 
   describe command("df --local -P | awk '{ if (NR!=1) print $6 }' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \)") do
@@ -398,12 +451,12 @@ control 'cis-dil-benchmark-1.1.21' do
   end
 end
 
-control 'cis-dil-benchmark-1.1.22' do
+control 'cis-dil-benchmark-1.1.26' do
   title 'Disable Automounting'
   desc  "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.\n\nRationale: With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
   impact 1.0
 
-  tag cis: 'distribution-independent-linux:1.1.22'
+  tag cis: 'distribution-independent-linux:1.1.26'
   tag level: 1
 
   describe.one do

--- a/controls/1_1_filesystem_configuration.rb
+++ b/controls/1_1_filesystem_configuration.rb
@@ -237,6 +237,8 @@ control 'cis-dil-benchmark-1.1.9' do
   end
 end
 
+# There is a mistake in the official CIS DIL documentaion 1.1.10-1.1.14 are
+# duplicates of 1.1.9. So I used "skipped" to keep the order of the numbering.
 control 'cis-dil-benchmark-1.1.10' do
   title 'Ensure noexec option set on /var/tmp partition'
   desc  "The noexec mount option specifies that the filesystem cannot contain executable binaries.\n\nRationale: Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -245,8 +247,8 @@ control 'cis-dil-benchmark-1.1.10' do
   tag cis: 'distribution-independent-linux:1.1.10'
   tag level: 1
 
-  describe mount('/var/tmp') do
-    its(:options) { should include 'noexec' }
+  describe 'cis-dil-benchmark-1.1.10' do
+    skip 'Duplicate of cis-dil-benchmark-1.1.9'
   end
 end
 
@@ -258,8 +260,9 @@ control 'cis-dil-benchmark-1.1.11' do
   tag cis: 'distribution-independent-linux:1.1.11'
   tag level: 1
 
-  describe mount('/var/tmp') do
-    its(:options) { should include 'noexec' }
+  
+  describe 'cis-dil-benchmark-1.1.11' do
+    skip 'Duplicate of cis-dil-benchmark-1.1.9'
   end
 end
 
@@ -271,8 +274,8 @@ control 'cis-dil-benchmark-1.1.12' do
   tag cis: 'distribution-independent-linux:1.1.12'
   tag level: 1
 
-  describe mount('/var/tmp') do
-    its(:options) { should include 'noexec' }
+  describe 'cis-dil-benchmark-1.1.12' do
+    skip 'Duplicate of cis-dil-benchmark-1.1.9'
   end
 end
 
@@ -284,8 +287,8 @@ control 'cis-dil-benchmark-1.1.13' do
   tag cis: 'distribution-independent-linux:1.1.13'
   tag level: 1
 
-  describe mount('/var/tmp') do
-    its(:options) { should include 'noexec' }
+  describe 'cis-dil-benchmark-1.1.13' do
+    skip 'Duplicate of cis-dil-benchmark-1.1.9'
   end
 end
 
@@ -296,9 +299,9 @@ control 'cis-dil-benchmark-1.1.14' do
 
   tag cis: 'distribution-independent-linux:1.1.14'
   tag level: 1
-
-  describe mount('/var/tmp') do
-    its(:options) { should include 'noexec' }
+  
+  describe 'cis-dil-benchmark-1.1.14' do
+    skip 'Duplicate of cis-dil-benchmark-1.1.9'
   end
 end
 

--- a/controls/3_5_uncommon_network_protocols.rb
+++ b/controls/3_5_uncommon_network_protocols.rb
@@ -17,7 +17,7 @@
 
 title '3.5 Uncommon Network Protocols'
 
-control 'cis-dil-benchmark-3.5.1' do
+control ' ' do
   title 'Ensure DCCP is disabled'
   desc  "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery.\n\nRationale: If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
   impact 0.0

--- a/controls/3_5_uncommon_network_protocols.rb
+++ b/controls/3_5_uncommon_network_protocols.rb
@@ -17,7 +17,7 @@
 
 title '3.5 Uncommon Network Protocols'
 
-control ' ' do
+control 'cis-dil-benchmark-3.5.1' do
   title 'Ensure DCCP is disabled'
   desc  "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery.\n\nRationale: If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
   impact 0.0

--- a/controls/4_2_configure_logging.rb
+++ b/controls/4_2_configure_logging.rb
@@ -37,7 +37,7 @@ end
 
 control 'cis-dil-benchmark-4.2.1.2' do
   title 'Ensure logging is configured'
-  desc  "The /etc/rsyslog.conf file specifies rules for logging and which files are to be used to log certain classes of messages.\n\nRationale: A great deal of important security-related information is sent via rsyslog (e.g., successful and failed su attempts, failed login attempts, root login attempts, etc.)."
+  desc  "The /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files specifies rules for logging and which files are to be used to log certain classes of messages.\n\nRationale: A great deal of important security-related information is sent via rsyslog (e.g., successful and failed su attempts, failed login attempts, root login attempts, etc.)."
   impact 0.0
 
   tag cis: 'distribution-independent-linux:4.2.1.2'
@@ -50,6 +50,49 @@ control 'cis-dil-benchmark-4.2.1.2' do
   describe file('/etc/rsyslog.conf') do
     it { should exist }
   end
+
+  describe.one do
+    command('find /etc/rsyslog.d -name "*.conf"').stdout.split.each do |conf_file|      
+      describe file(conf_file) do
+          its(:content) { should match(%r{^\*.emerg(\s)+:omusrmsg:\*}) }
+          its(:content) { should match(%r{^mail.\*(\s)+-/var/log/mail}) }
+          its(:content) { should match(%r{^mail.info(\s)+-/var/log/mail.info}) }
+          its(:content) { should match(%r{^mail.warning(\s)+-/var/log/mail.warn}) }
+          its(:content) { should match(%r{^mail.err(\s)+/var/log/mail.err}) }
+          its(:content) { should match(%r{^news.crit(\s)+-/var/log/news/news.crit}) }
+          its(:content) { should match(%r{^news.crit(\s)+-/var/log/news/news.crit}) }
+          its(:content) { should match(%r{^news.notice(\s)+-/var/log/news/news.notice}) }
+          its(:content) { should match(%r{^\*.=warning;\*.=err(\s)+-/var/log/warn}) }
+          its(:content) { should match(%r{^\*.crit(\s)+/var/log/warn}) }
+          its(:content) { should match(%r{^\*.\*;mail.none;news.none(\s)+-/var/log/messages}) }
+          its(:content) { should match(%r{^local0,local1.\*(\s)+-/var/log/localmessages}) }
+          its(:content) { should match(%r{^local2,local3.\*(\s)+-/var/log/localmessages}) }
+          its(:content) { should match(%r{^local2,local3.\*(\s)+-/var/log/localmessages}) }
+          its(:content) { should match(%r{^local4,local5.\*(\s)+-/var/log/localmessages}) }
+          its(:content) { should match(%r{^local6,local7.\*(\s)+-/var/log/localmessages}) }        
+      end      
+    end
+
+    describe file('/etc/rsyslog.conf') do      
+      its(:content) { should match(%r{^\*.emerg(\s)+:omusrmsg:\*}) }
+      its(:content) { should match(%r{^mail.\*(\s)+-/var/log/mail}) }
+      its(:content) { should match(%r{^mail.info(\s)+-/var/log/mail.info}) }
+      its(:content) { should match(%r{^mail.warning(\s)+-/var/log/mail.warn}) }
+      its(:content) { should match(%r{^mail.err(\s)+/var/log/mail.err}) }
+      its(:content) { should match(%r{^news.crit(\s)+-/var/log/news/news.crit}) }
+      its(:content) { should match(%r{^news.crit(\s)+-/var/log/news/news.crit}) }
+      its(:content) { should match(%r{^news.notice(\s)+-/var/log/news/news.notice}) }
+      its(:content) { should match(%r{^\*.=warning;\*.=err(\s)+-/var/log/warn}) }
+      its(:content) { should match(%r{^\*.crit(\s)+/var/log/warn}) }
+      its(:content) { should match(%r{^\*.\*;mail.none;news.none(\s)+-/var/log/messages}) }
+      its(:content) { should match(%r{^local0,local1.\*(\s)+-/var/log/localmessages}) }
+      its(:content) { should match(%r{^local2,local3.\*(\s)+-/var/log/localmessages}) }
+      its(:content) { should match(%r{^local2,local3.\*(\s)+-/var/log/localmessages}) }
+      its(:content) { should match(%r{^local4,local5.\*(\s)+-/var/log/localmessages}) }
+      its(:content) { should match(%r{^local6,local7.\*(\s)+-/var/log/localmessages}) }
+    end
+  end
+
 end
 
 control 'cis-dil-benchmark-4.2.1.3' do

--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -156,25 +156,6 @@ control 'cis-dil-benchmark-5.2.10' do
 end
 
 control 'cis-dil-benchmark-5.2.11' do
-  title 'Ensure only approved ciphers are used'
-  desc "This variable limits the types of ciphers that SSH can use during communication.\n\nRationale: Based on research conducted at various institutions, it was determined that the symmetric portion of the SSH Transport Protocol (as described in RFC 4253) has security weaknesses that allowed recovery of up to 32 bits of plaintext from a block of ciphertext that was encrypted with the Cipher Block Chaining (CBD) method. From that research, new Counter mode algorithms (as described in RFC4344) were designed that are not vulnerable to these types of attacks and these algorithms are now recommended for standard use."
-  impact 1.0
-
-  tag cis: 'distribution-independent-linux:5.2.11'
-  tag level: 1
-
-  describe sshd_config do
-    its(:Ciphers) { should_not be_nil }
-  end
-
-  if sshd_config.Ciphers
-    describe sshd_config.Ciphers.split(',').each do
-      it { should_not match(/-cbc$/) }
-    end
-  end
-end
-
-control 'cis-dil-benchmark-5.2.12' do
   title 'Ensure only approved MAC algorithms are used'
   desc  "This variable limits the types of MAC algorithms that SSH can use during communication.\n\nRationale: MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information"
   impact 1.0
@@ -206,7 +187,7 @@ control 'cis-dil-benchmark-5.2.12' do
   end
 end
 
-control 'cis-dil-benchmark-5.2.13' do
+control 'cis-dil-benchmark-5.2.12' do
   title 'Ensure SSH Idle Timeout Interval is configured'
   desc  "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the ClientAliveCountMax variable is set, sshd will send client alive messages at every ClientAliveInterval interval. When the number of consecutive client alive messages are sent with no response from the client, the ssh session is terminated. For example, if the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time.\n\nRationale: Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value at least reduces the risk of this happening.. While the recommended setting is 300 seconds (5 minutes), set this timeout value based on site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client session will be terminated after 5 minutes of idle time and no keepalive messages will be sent."
   impact 1.0
@@ -220,7 +201,7 @@ control 'cis-dil-benchmark-5.2.13' do
   end
 end
 
-control 'cis-dil-benchmark-5.2.14' do
+control 'cis-dil-benchmark-5.2.13' do
   title 'Ensure SSH LoginGraceTime is set to one minute or less'
   desc  "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access.\n\nRationale: Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
   impact 1.0
@@ -233,7 +214,7 @@ control 'cis-dil-benchmark-5.2.14' do
   end
 end
 
-control 'cis-dil-benchmark-5.2.15' do
+control 'cis-dil-benchmark-5.2.14' do
   title 'Ensure SSH access is limited'
   desc "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged:
   AllowUsers\nThe AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of comma separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. AllowGroups\nThe AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of comma separated group names. Numeric group IDs are not recognized with this variable. DenyUsers\nThe DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of comma separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. DenyGroups\nThe DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of comma separated group names. Numeric group IDs are not recognized with this variable.\n\nRationale: Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -251,7 +232,7 @@ control 'cis-dil-benchmark-5.2.15' do
   end
 end
 
-control 'cis-dil-benchmark-5.2.16' do
+control 'cis-dil-benchmark-5.2.15' do
   title 'Ensure SSH warning banner is configured'
   desc  "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed.\n\nRationale: Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
   impact 1.0

--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -157,7 +157,7 @@ control 'cis-dil-benchmark-5.4.2' do
       end
 
       describe shadow(user.user) do
-        its(:password) { should be_all { |m| m == '*' } }
+        its(:passwords) { should be_all { |m| m == '*' } }
       end
     end
   end

--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -181,10 +181,8 @@ control 'cis-dil-benchmark-6.1.6' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should_not be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
-    it { should_not be_readable.by 'other' }
     it { should_not be_writable.by 'other' }
     it { should_not be_executable.by 'other' }
     its(:uid) { should cmp 0 }

--- a/inspec.lock
+++ b/inspec.lock
@@ -1,0 +1,3 @@
+---
+lockfile_version: 1
+depends: []


### PR DESCRIPTION
Correct the `/etc/passwd-` check According to the actual CiS documentation:

```
Run the following command and verify Uid and Gid are both 0/root and Access is 644 or more restrictive:
```
From the latest CiS documentation (CIS_Distribution_Independent_Linux_Benchmark_v1.1.0)