### PR TITLE
Change `password` to `passwords`

### DIFF
--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -134,7 +134,7 @@ control 'cis-dil-benchmark-5.4.2' do
       end
 
       describe shadow(user.user) do
-        its(:password) { should be_all { |m| m == '*' } }
+        its(:passwords) { should be_all { |m| m == '*' } }
       end
     end
   end


### PR DESCRIPTION
This removes the deprecation warnings from InSpec. The 'password' matcher was deprecated and changed to 'passwords' in InSpec 3.0

Example of deprecation message:

```
[DEPRECATION] The shadow `password` property is deprecated and will be removed in InSpec 3.0.  Please use `passwords` instead.
```