### PR TITLE
Fixes

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -96,7 +96,7 @@ control 'cis-dil-benchmark-4.1.3' do
   only_if { cis_level == 2 }
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
+    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg /usr/share/oem/grub.cfg).each do |f|
       describe file(f) do
         its(:content) { should match(/audit=1/) }
       end

--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -181,10 +181,8 @@ control 'cis-dil-benchmark-6.1.6' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should_not be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
-    it { should_not be_readable.by 'other' }
     it { should_not be_writable.by 'other' }
     it { should_not be_executable.by 'other' }
     its(:uid) { should cmp 0 }


### PR DESCRIPTION
* Add path to CoreOS `grub.cfg` for detecting audit kernel parameter
* Fix permissions check for `/etc/passwd-`

#### CIS DIL v1.1.0 shows:
```shell
# Status
stat /etc/passwd- 
# => Access: (0644/-rw-------) Uid: ( 0/ root) Gid: ( 0/ root)

# Remediation
chown root:root /etc/passwd-
chmod u-x,go-wx /etc/passwd-
```
