### PR TITLE
Ensure /etc/group- /etc/shadow- and /etc/gshadow- match their respect…

### DIFF
--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -86,7 +86,6 @@ control 'cis-dil-benchmark-6.1.3' do
       it { should be_readable.by 'owner' }
       it { should be_writable.by 'owner' }
       it { should_not be_executable.by 'owner' }
-      it { should be_readable.by 'group' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
       it { should_not be_readable.by 'other' }
@@ -153,7 +152,6 @@ control 'cis-dil-benchmark-6.1.5' do
       it { should be_readable.by 'owner' }
       it { should be_writable.by 'owner' }
       it { should_not be_executable.by 'owner' }
-      it { should be_readable.by 'group' }
       it { should_not be_writable.by 'group' }
       it { should_not be_executable.by 'group' }
       it { should_not be_readable.by 'other' }
@@ -206,7 +204,6 @@ control 'cis-dil-benchmark-6.1.7' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }
@@ -260,7 +257,6 @@ control 'cis-dil-benchmark-6.1.9' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }

--- a/controls/6_1_system_file_permissions.rb
+++ b/controls/6_1_system_file_permissions.rb
@@ -206,7 +206,7 @@ control 'cis-dil-benchmark-6.1.7' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should_not be_readable.by 'group' }
+    it { should be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }
@@ -233,10 +233,10 @@ control 'cis-dil-benchmark-6.1.8' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should_not be_readable.by 'group' }
+    it { should be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
-    it { should_not be_readable.by 'other' }
+    it { should be_readable.by 'other' }
     it { should_not be_writable.by 'other' }
     it { should_not be_executable.by 'other' }
     its(:uid) { should cmp 0 }
@@ -260,7 +260,7 @@ control 'cis-dil-benchmark-6.1.9' do
     it { should be_readable.by 'owner' }
     it { should be_writable.by 'owner' }
     it { should_not be_executable.by 'owner' }
-    it { should_not be_readable.by 'group' }
+    it { should be_readable.by 'group' }
     it { should_not be_writable.by 'group' }
     it { should_not be_executable.by 'group' }
     it { should_not be_readable.by 'other' }


### PR DESCRIPTION
Some more fixes...

All shadowfile-like files with a dash appended are backups of their original.

There is no reason the permissions should differ between the two, so the file mode for lets say `/etc/shadow` should also apply to `/etc/shadow-`

I compared the controls side-by-side and found some deviation.  This should bring them back in-line.

e.g. 6.1.3 - /etc/shadow should match 6.1.7 - /etc/shadow-

On stock CoreOS, I found that the the non-dash controls pass, and the dash backup files fail.

## Example of Deviation

### /etc/shadow
https://github.com/dev-sec/cis-dil-benchmark/blob/88e29f56bc3ac2a260a7913b22d93d3edd7c9118/controls/6_1_system_file_permissions.rb#L89

### /etc/shadow-
https://github.com/dev-sec/cis-dil-benchmark/blob/88e29f56bc3ac2a260a7913b22d93d3edd7c9118/controls/6_1_system_file_permissions.rb#L209