### PR TITLE
Update 3.3 IPv6 to support Amazon Linux 2

### DIFF
--- a/controls/3_3_ipv6.rb
+++ b/controls/3_3_ipv6.rb
@@ -28,7 +28,7 @@ control 'cis-dil-benchmark-3.3.1' do
   only_if do
     ipv6_enabled = true
 
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst).each do |f|
+    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
       grub_file = file(f)
       if !grub_file.content.nil? && grub_file.content.match(/ipv6\.disable=1/)
         ipv6_enabled = false
@@ -58,7 +58,7 @@ control 'cis-dil-benchmark-3.3.2' do
   only_if do
     ipv6_enabled = true
 
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst).each do |f|
+    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
       grub_file = file(f)
       if !grub_file.content.nil? && grub_file.content.match(/ipv6\.disable=1/)
         ipv6_enabled = false
@@ -86,7 +86,7 @@ control 'cis-dil-benchmark-3.3.3' do
   tag level: 1
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst).each do |f|
+    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
       describe file(f) do
         its(:content) { should match(/ipv6\.disable=1/) }
       end


### PR DESCRIPTION
Amazon Linux 2 uses /boot/grub2/grub.cfg (see also pull #17).