### PR TITLE
iptables: support conntrack module

### DIFF
--- a/controls/3_6_firewall_configuration.rb
+++ b/controls/3_6_firewall_configuration.rb
@@ -74,9 +74,15 @@ control 'cis-dil-benchmark-3.6.4' do
   tag level: 1
 
   %w(tcp udp icmp).each do |proto|
-    describe iptables do
-      it { should have_rule("-A OUTPUT -p #{proto} -m state --state NEW,ESTABLISHED -j ACCEPT") }
-      it { should have_rule("-A INPUT -p #{proto} -m state --state ESTABLISHED -j ACCEPT") }
+    describe.one do 
+        describe iptables do
+          it { should have_rule("-A OUTPUT -p #{proto} -m state --state NEW,ESTABLISHED -j ACCEPT")  }
+          it { should have_rule("-A INPUT -p #{proto} -m state --state ESTABLISHED -j ACCEPT") }
+        end
+        describe iptables do
+          it { should have_rule("-A OUTPUT -p #{proto} -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT") }
+          it { should have_rule("-A INPUT -p #{proto} -m conntrack --ctstate ESTABLISHED -j ACCEPT") }
+        end
     end
   end
 end


### PR DESCRIPTION
Later distros use the conntrack module, a superset of state.