### PR TITLE
Refactor out grub config to profile file

### DIFF
--- a/controls/1_4_secure_boot_settings.rb
+++ b/controls/1_4_secure_boot_settings.rb
@@ -26,7 +26,7 @@ control 'cis-dil-benchmark-1.4.1' do
   tag level: 1
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
+    grub_conf.locations.each do |f|
       describe file(f) do
         it { should exist }
         it { should_not be_readable.by 'group' }
@@ -51,7 +51,7 @@ control 'cis-dil-benchmark-1.4.2' do
   tag level: 1
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub/grub.cfg).each do |f|
+    grub_conf.locations.each do |f|
       describe file(f) do
         its(:content) { should match(/^set superusers/) }
         its(:content) { should match(/^password/) }

--- a/controls/1_6_mandatory_access_control.rb
+++ b/controls/1_6_mandatory_access_control.rb
@@ -34,7 +34,7 @@ control 'cis-dil-benchmark-1.6.1.1' do
   end
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst).each do |f|
+    grub_conf.locations.each do |f|
       describe file(f) do
         its(:content) { should_not match(/selinux=0/) }
         its(:content) { should_not match(/enforcing=0/) }
@@ -169,7 +169,7 @@ control 'cis-dil-benchmark-1.6.2.1' do
   only_if { cis_level == 2 && package('apparmor').installed? }
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst).each do |f|
+    grub_conf.locations.each do |f|
       describe file(f) do
         its(:content) { should_not match(/apparmor=0/) }
       end

--- a/controls/3_3_ipv6.rb
+++ b/controls/3_3_ipv6.rb
@@ -28,7 +28,7 @@ control 'cis-dil-benchmark-3.3.1' do
   only_if do
     ipv6_enabled = true
 
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
+    grub_conf.locations.each do |f|
       grub_file = file(f)
       if !grub_file.content.nil? && grub_file.content.match(/ipv6\.disable=1/)
         ipv6_enabled = false
@@ -58,7 +58,7 @@ control 'cis-dil-benchmark-3.3.2' do
   only_if do
     ipv6_enabled = true
 
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
+    grub_conf.locations.each do |f|
       grub_file = file(f)
       if !grub_file.content.nil? && grub_file.content.match(/ipv6\.disable=1/)
         ipv6_enabled = false
@@ -86,7 +86,7 @@ control 'cis-dil-benchmark-3.3.3' do
   tag level: 1
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg).each do |f|
+    grub_conf.locations.each do |f|
       describe file(f) do
         its(:content) { should match(/ipv6\.disable=1/) }
       end

--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -96,7 +96,7 @@ control 'cis-dil-benchmark-4.1.3' do
   only_if { cis_level == 2 }
 
   describe.one do
-    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg /usr/share/oem/grub.cfg).each do |f|
+    grub_conf.locations.each do |f|
       describe file(f) do
         its(:content) { should match(/audit=1/) }
       end

--- a/libraries/grubconf.rb
+++ b/libraries/grubconf.rb
@@ -1,0 +1,7 @@
+class GrubConf < Inspec.resource(1)
+  name 'grub_conf'
+
+  def locations
+    %w(/boot/grub/grub.conf /boot/grub/grub.cfg /boot/grub/menu.lst /boot/boot/grub/grub.conf /boot/boot/grub/grub.cfg /boot/boot/grub/menu.lst /boot/grub2/grub.cfg)
+  end
+end


### PR DESCRIPTION
See #17, #74, etc.

This pulls the canonical locations for the grub.cfg file into one spot so we aren't chasing our tail in multiple controls. Not sure if the pattern is appropriate, I'm not an ops/inspec guy.