### PR TITLE
SSH config: Allow seconds & minutes config for grace time

### DIFF
--- a/controls/3_6_firewall_configuration.rb
+++ b/controls/3_6_firewall_configuration.rb
@@ -74,15 +74,15 @@ control 'cis-dil-benchmark-3.6.4' do
   tag level: 1
 
   %w(tcp udp icmp).each do |proto|
-    describe.one do 
-        describe iptables do
-          it { should have_rule("-A OUTPUT -p #{proto} -m state --state NEW,ESTABLISHED -j ACCEPT")  }
-          it { should have_rule("-A INPUT -p #{proto} -m state --state ESTABLISHED -j ACCEPT") }
-        end
-        describe iptables do
-          it { should have_rule("-A OUTPUT -p #{proto} -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT") }
-          it { should have_rule("-A INPUT -p #{proto} -m conntrack --ctstate ESTABLISHED -j ACCEPT") }
-        end
+    describe.one do
+      describe iptables do
+        it { should have_rule("-A OUTPUT -p #{proto} -m state --state NEW,ESTABLISHED -j ACCEPT") }
+        it { should have_rule("-A INPUT -p #{proto} -m state --state ESTABLISHED -j ACCEPT") }
+      end
+      describe iptables do
+        it { should have_rule("-A OUTPUT -p #{proto} -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT") }
+        it { should have_rule("-A INPUT -p #{proto} -m conntrack --ctstate ESTABLISHED -j ACCEPT") }
+      end
     end
   end
 end

--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -229,7 +229,9 @@ control 'cis-dil-benchmark-5.2.14' do
   tag level: 1
 
   describe sshd_config do
-    its(:LoginGraceTime) { should cmp <= 60 }
+    its(:LoginGraceTime) do
+      should satisfy { |x| x == '1m' || ((matches = x.match(/(?<secs>[0-9]+)s?/)) && Integer(matches[:secs]) <= 60) }
+    end
   end
 end
 


### PR DESCRIPTION
Some configs in the wild use "30s" or "1m" (including the dev-sec/ansible-ssh-hardening repo)