### PR TITLE
Check for `pool` or `server` in chrony.conf

### DIFF
--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -108,7 +108,7 @@ control 'cis-dil-benchmark-2.2.1.3' do
   describe.one do
     %w(/etc/chrony/chrony.conf /etc/chrony.conf).each do |f|
       describe file(f) do
-        its(:content) { should match(/^server\s+\S+/) }
+        its('content') { should match(/^(pool|server)\s+\S+/) }
       end
     end
   end


### PR DESCRIPTION
The chrony cookbook uses `pool` https://github.com/chef-cookbooks/chrony/blob/master/templates/chrony_client.conf.erb#L8

`pool` is also referenced in
https://chrony.tuxfamily.org/faq.html#_what_is_the_minimum_recommended_configuration_for_an_ntp_client

Signed-off-by: joe.nuspl <joe.nuspl@workday.com>