### PR TITLE
fix(5.2.2): ensured correct host key permissions are checked on RedHa…

### DIFF
--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -59,15 +59,16 @@ control 'cis-dil-benchmark-5.2.2' do
   tag cis: 'distribution-independent-linux:5.2.2'
   tag level: 1
 
+  expected_gid = 0
+  expected_gid = 995 if os.redhat?
+
+  expected_perms = '0600'
+  expected_perms = '0640' if os.redhat?
+
   command('find /etc/ssh -xdev -type f -name "ssh_host_*_key"').stdout.split.each do |f|
     describe file(f) do
-      it { should_not be_readable.by 'group' }
-      it { should_not be_writable.by 'group' }
-      it { should_not be_executable.by 'group' }
-      it { should_not be_readable.by 'other' }
-      it { should_not be_writable.by 'other' }
-      it { should_not be_executable.by 'other' }
-      its('gid') { should cmp 0 }
+      it { should_not be_more_permissive_than(expected_perms) }
+      its('gid') { should cmp expected_gid }
       its('uid') { should cmp 0 }
     end
   end


### PR DESCRIPTION
While the CIS DIL Benchmark expects 0600 root:root permissions on all private host key files, this appears to be undesired behavior on RedHat systems where the openssh package creates ssh host key files with the group ssh_keys and permissions 0640 for user host-based ssh authentification to work (the setuid helper program /usr/libexec/openssh/ssh-keysign is used to read the keys and requires these permissions).

We are thinking that instead of waivering this control ourselves, this profile should be updated to reflect the recommended RedHat configuration.

Relevant issues:
https://bugzilla.redhat.com/show_bug.cgi?id=1372070
https://github.com/ComplianceAsCode/content/issues/1542
https://github.com/ComplianceAsCode/content/pull/1556/files
https://github.com/xcat2/xcat-core/issues/2617
