### PR TITLE
revert to using cmp for 1.6.3.2 because of implicit string conversion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,5 @@ Lint/AmbiguousBlockAssociation:
   Enabled: false
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
+Style/NumericPredicate:
+  Enabled: false

--- a/controls/1_6_mandatory_access_control.rb
+++ b/controls/1_6_mandatory_access_control.rb
@@ -183,7 +183,7 @@ control 'cis-dil-benchmark-1.6.3.2' do
   only_if { cis_level == 2 && package('apparmor').installed? }
 
   describe command('apparmor_status --profiled') do
-    its('stdout') { should cmp.positive? }
+    its('stdout') { should cmp > 0 }
   end
 
   describe command('apparmor_status --complaining') do


### PR DESCRIPTION
fixes #105 