### PR TITLE
add dependency to chef-config for CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ group :tools do
 end
 
 source 'https://packagecloud.io/cinc-project/stable' do
+  gem 'chef-config'
   gem 'cinc-auditor-bin'
 end


### PR DESCRIPTION
the gem chef-config is contained in both repos rubygems.org and cinc-project. This seems to confuse bundler when installing gems.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>