### PR TITLE
fix(5.2.5): allow INFO as SSH LogLevel

### DIFF
--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -138,8 +138,10 @@ control 'cis-dil-benchmark-5.2.5' do
   tag cis: 'distribution-independent-linux:5.2.5'
   tag level: 1
 
+  allowed_log_levels = %w[INFO VERBOSE]
+
   describe sshd_config do
-    its('LogLevel') { should eq 'VERBOSE' }
+    its('LogLevel') { should be_in allowed_log_levels }
   end
 end
 


### PR DESCRIPTION
The audit procedure for this control states that 'VERBOSE' _OR_ 'INFO'
are valid configuration values.

Fixes dev-sec/cis-dil-benchmark#109

on-behalf-of: @Logicworks <dmiguel@logicworks.net>
Signed-off-by: Deric Miguel <dmiguel@logicworks.net>