### PR TITLE
use input instead of attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## [0.4.11](https://github.com/dev-sec/cis-dil-benchmark/tree/0.4.11) (2021-03-22)
+## [0.4.11](https://github.com/dev-sec/cis-dil-benchmark/tree/0.4.11) (2021-04-24)
 
 [Full Changelog](https://github.com/dev-sec/cis-dil-benchmark/compare/0.4.10...0.4.11)
+
+**Fixed bugs:**
+
+- cis-dil-benchmark-5.2.5 should allow sshd LogLevel to be INFO or VERBOSE [\#109](https://github.com/dev-sec/cis-dil-benchmark/issues/109)
+- fix\(5.2.5\): allow INFO as SSH LogLevel [\#111](https://github.com/dev-sec/cis-dil-benchmark/pull/111) ([deric4](https://github.com/deric4))
+
+**Closed issues:**
+
+- this repo should be labelled inspec [\#110](https://github.com/dev-sec/cis-dil-benchmark/issues/110)
 
 **Merged pull requests:**
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,24 +25,3 @@ namespace :test do
     pp profile.check
   end
 end
-
-task :changelog do
-  # Automatically generate a changelog for this project. Only loaded if
-  # the necessary gem is installed. By default its picking up the version from
-  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts " * Generating changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
-    config.user = 'dev-sec'
-    config.project = 'linux-baseline'
-  end
-  Rake::Task[:changelog].execute
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
-
-end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'rake/testtask'
@@ -20,23 +19,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec cinc-auditor check #{dir} --format json --log-level=error | jq .")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-begin
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+
   require 'yaml'
   metadata = YAML.load_file('inspec.yml')
   v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
+  puts " * Generating changelog for version #{v}"
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     config.future_release = v
+    config.user = 'dev-sec'
+    config.project = 'linux-baseline'
   end
+  Rake::Task[:changelog].execute
 rescue LoadError
   puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
+
 end

--- a/controls/1_6_mandatory_access_control.rb
+++ b/controls/1_6_mandatory_access_control.rb
@@ -17,7 +17,7 @@
 #
 # author: Kristian Vlaardingerbroek
 
-cis_level = attribute('cis_level')
+cis_level = input('cis_level')
 
 title '1.6 Mandatory Access Control'
 

--- a/controls/3_4_uncommon_network_protocols.rb
+++ b/controls/3_4_uncommon_network_protocols.rb
@@ -17,7 +17,7 @@
 #
 # author: Kristian Vlaardingerbroek
 
-cis_level = attribute('cis_level')
+cis_level = input('cis_level')
 
 title '3.4 Uncommon Network Protocols'
 

--- a/controls/3_7_disable_ipv6.rb
+++ b/controls/3_7_disable_ipv6.rb
@@ -17,7 +17,7 @@
 #
 # author: Kristian Vlaardingerbroek
 
-cis_level = attribute('cis_level')
+cis_level = input('cis_level')
 
 title '3.7 Disable IPv6'
 

--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -17,7 +17,7 @@
 #
 # author: Kristian Vlaardingerbroek
 
-cis_level = attribute('cis_level')
+cis_level = input('cis_level')
 
 title '4.1 Configure System Accounting (auditd)'
 

--- a/controls/5_2_ssh_server_configuration.rb
+++ b/controls/5_2_ssh_server_configuration.rb
@@ -17,7 +17,7 @@
 #
 # author: Kristian Vlaardingerbroek
 
-cis_level = attribute('cis_level')
+cis_level = input('cis_level')
 
 title '5.2 SSH Server Configuration'
 

--- a/controls/5_4_user_accounts_and_environments.rb
+++ b/controls/5_4_user_accounts_and_environments.rb
@@ -17,7 +17,7 @@
 #
 # author: Kristian Vlaardingerbroek
 
-cis_level = attribute('cis_level')
+cis_level = input('cis_level')
 
 title '5.4 User Accounts and Environments'
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -7,7 +7,7 @@ copyright_email: kvlaardingerbroek@schubergphilis.com
 license: Apache-2.0
 summary: An InSpec Compliance profile for the CIS Distribution Independent Linux Benchmark
 version: 0.4.11
-inspec_version: '>= 2.3.5'
+inspec_version: '>= 4.6.3'
 supports:
     - platform-family: linux
 inputs:


### PR DESCRIPTION
In the last versions of Inspec and cinc-auditor, attribute is deprecated and input should be used.

https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper/