### PR TITLE
cis-dil-benchmark-5.3.4 should match spaces better

### DIFF
--- a/controls/5_3_configure_pam.rb
+++ b/controls/5_3_configure_pam.rb
@@ -169,7 +169,7 @@ control 'cis-dil-benchmark-5.3.4' do
   describe.one do
     %w[common-password system-auth password-auth].each do |f|
       describe file("/etc/pam.d/#{f}") do
-        its('content') { should match(/^password(\s+\S+\s+)+pam_unix\.so\s+(\S+\s+)*sha512/) }
+        its('content') { should match(/^password\s+(\S+\s+)+pam_unix\.so\s+(\S+\s+)*sha512/) }
       end
     end
   end


### PR DESCRIPTION
5.3.3 uses this matching logic and it works, 

password        [success=1 default=ignore]      pam_unix.so obscure use_authtok try_first_pass sha512  remember=5

is matched by 5.3.3 regular expression, but  didn't match 5.3.4 because of a space between "1" and "default"

Signed-off-by: Peter Turner <pturner@uwalumni.com>