### PR TITLE
CIS4.1.5 fix 64 bit support

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -144,8 +144,6 @@ control 'cis-dil-benchmark-4.1.5' do
   only_if { cis_level == 2 }
 
   describe file('/etc/audit/audit.rules') do
-    its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change$/) }
-    its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S clock_settime -k time-change$/) }
     its('content') { should match %r{^-w /etc/localtime -p wa -k time-change$} }
   end
 
@@ -154,6 +152,13 @@ control 'cis-dil-benchmark-4.1.5' do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S adjtimex -S settimeofday -k time-change$/) }
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S clock_settime -k time-change$/) }
     end
+  elsif command('uname -m').stdout.strip == 'i386'
+    describe file('/etc/audit/audit.rules') do
+      its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change$/) }
+      its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S clock_settime -k time-change$/) }
+    end
+  else
+    raise "unsupported architecture"
   end
 end
 


### PR DESCRIPTION
This fixes the logic so that 32 bit checks only run on 32 bit sytems and 64 bit checks run on 64 bit systems. 

Before this change, the 32 bit check would _always_ run, even on 64 bit systems and would give false failures. 


![Screen Shot 2022-11-01 at 9 14 22 PM](https://user-images.githubusercontent.com/109251274/199388484-43580f5f-a3a0-4ad3-bf55-9a785964ac17.png)
![Screen Shot 2022-11-01 at 9 15 28 PM](https://user-images.githubusercontent.com/109251274/199388567-d8036af8-6e13-4f38-a12a-2d1ad3a2420c.png)


Note: I'm not sure how to test this on non x86 systems. Any guidance about how to `raise` a failure appreciated. 

OSX: 
```
uname -m
arm64
```

Ubuntu
```
uname -m
aarch64
```