### PR TITLE
Document why audit.rules should include 32 on 64 bit systems

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -143,6 +143,7 @@ control 'cis-dil-benchmark-4.1.5' do
 
   only_if { cis_level == 2 }
 
+  # arch=b32 should be set on both 32bit and 64bit systems https://security.stackexchange.com/a/242462
   describe file('/etc/audit/audit.rules') do
     its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change$/) }
     its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S clock_settime -k time-change$/) }


### PR DESCRIPTION
Adds documentation based on this comment: https://github.com/dev-sec/cis-dil-benchmark/pull/131#issuecomment-1299526589