### PR TITLE
Local loopback is 127.0.0.0/8, not just 127.0.0.1

### DIFF
--- a/controls/3_5_firewall_configuration.rb
+++ b/controls/3_5_firewall_configuration.rb
@@ -117,7 +117,7 @@ control 'cis-dil-benchmark-3.5.1.4' do
   tag cis: 'distribution-independent-linux:3.5.1.4'
   tag level: 1
 
-  port.where { address !~ /^(127\.0\.0\.1|::1)$/ }.ports.each do |port|
+  port.where { address !~ /^(127\.|::1)$/ }.ports.each do |port|
     describe "Firewall rule should exist for port #{port}" do
       subject { ip6tables.retrieve_rules.any? { |s| s =~ /\s--(dport|dports) #{port}\s/ } }
       it { should be true }
@@ -214,7 +214,7 @@ control 'cis-dil-benchmark-3.5.2.4' do
   tag cis: 'distribution-independent-linux:3.5.2.4'
   tag level: 1
 
-  port.where { address !~ /^(127\.0\.0\.1|::1)$/ }.ports.each do |port|
+  port.where { address !~ /^(127\.|::1)$/ }.ports.each do |port|
     describe "Firewall rule should exist for port #{port}" do
       subject { iptables.retrieve_rules.any? { |s| s =~ /\s--(dport|dports) #{port}\s/ } }
       it { should be true }


### PR DESCRIPTION
Updated to only search for `/^(127\.|::1)$/` which conforms to RFC 5735

https://www.rfc-editor.org/rfc/rfc5735

For example, Ubuntu listens on 127.0.0.53:53 for local DNS requests. This pull request would fix a false-positive on Ubuntu distributions without a firewall rule to allow port 53 to a local loopback address, which is already allowed with all loopback traffic.