### PR TITLE
fix: allow alternative output for sestatus policy

### DIFF
--- a/controls/1_6_mandatory_access_control.rb
+++ b/controls/1_6_mandatory_access_control.rb
@@ -94,7 +94,7 @@ control 'cis-dil-benchmark-1.6.2.3' do
   end
 
   describe command('sestatus') do
-    its('stdout') { should match /Policy from config file:\s+(targeted|mls)/ }
+    its('stdout') { should match /(Loaded policy name|Policy from config file):\s+(targeted|mls)/ }
   end
 
   only_if { cis_level == 2 }


### PR DESCRIPTION
It seems like some versions of sestatus do not output `Policy from config file`, at least on Amazon Linux 2023 I can't get this from `sestatus` after appying ansible-collection-hardening's os_hardening role and rebooting.

Also looks like others have this condition https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2017-12-14/finding/V-71991:

> If the "Policy from config file" is not set to "targeted", or the "Loaded policy name" is not set to "targeted", this is a finding.

/cc @schurzi  @dlouzan