### PR TITLE
fix: handle chrony configuration sourced via amazon-chrony-config

### DIFF
--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -108,7 +108,7 @@ control 'cis-dil-benchmark-2.2.1.3' do
   end
 
   # Amazon Linux sources configuration from /run/chrony.d
-  chrony_conf_files = ["/etc/chrony/chrony.conf", "/etc/chrony.conf"]
+  chrony_conf_files = ['/etc/chrony/chrony.conf', '/etc/chrony.conf']
   chrony_conf_files += command('find /run/chrony.d -name \'*.sources\'').stdout.split
 
   describe.one do

--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -107,8 +107,12 @@ control 'cis-dil-benchmark-2.2.1.3' do
     package('chrony').installed? || command('chronyd').exist?
   end
 
+  # Amazon Linux sources configuration from /run/chrony.d
+  chrony_conf_files = ["/etc/chrony/chrony.conf", "/etc/chrony.conf"]
+  chrony_conf_files += command('find /run/chrony.d -name \'*.sources\'').stdout.split
+
   describe.one do
-    %w(/etc/chrony/chrony.conf /etc/chrony.conf).each do |f|
+    chrony_conf_files.each do |f|
       describe file(f) do
         its('content') { should match(/^(pool|server)\s+\S+/) }
       end


### PR DESCRIPTION
This is similar to #152. 

Amazon linux in recent versions will use `amazon-chrony-config` and will source its configuration in the root config file:

```
# Use NTP servers from DHCP.
sourcedir /run/chrony.d
```

See notes on AL images here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html#configure-amazon-time-service-amazon-linux-IPv4

/cc @schurzi @dlouzan