### PR TITLE
fix: cis-dil-benchmark-2.2.1.3 read /etc/chrony.d

### DIFF
--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -107,9 +107,10 @@ control 'cis-dil-benchmark-2.2.1.3' do
     package('chrony').installed? || command('chronyd').exist?
   end
 
-  # Amazon Linux sources configuration from /run/chrony.d
+  # Amazon Linux sources configuration from /run/chrony.d and /etc/chrony.d
   chrony_conf_files = ['/etc/chrony/chrony.conf', '/etc/chrony.conf']
   chrony_conf_files += command('find /run/chrony.d -name \'*.sources\'').stdout.split
+  chrony_conf_files += command('find /etc/chrony.d -name \'*.sources\'').stdout.split
 
   describe.one do
     chrony_conf_files.each do |f|


### PR DESCRIPTION
On AL2023, the folder /etc/chrony.d exists in which additional chrony sources can be configured.

Signed-off-by: Ivo van Doorn <ivovandoorn@samotics.com>