### PR TITLE
Add alternative package name for iptables

### DIFF
--- a/controls/3_5_firewall_configuration.rb
+++ b/controls/3_5_firewall_configuration.rb
@@ -230,7 +230,13 @@ control 'cis-dil-benchmark-3.5.3' do
   tag cis: 'distribution-independent-linux:3.5.3'
   tag level: 1
 
-  describe package('iptables') do
-    it { should be_installed }
+  describe.one do
+    describe package('iptables') do
+      it { should be_installed }
+    end
+
+    describe package('iptables-nft') do
+      it { should be_installed }
+    end
   end
 end


### PR DESCRIPTION
On AL2023 /usr/sbin/iptables is provided by the package iptables-nft Update the check to include this package name as option.

Signed-off-by: Ivo van Doorn <ivovandoorn@samotics.com>