### PR TITLE
Convert uname variable to global variable

### DIFF
--- a/controls/4_1_configure_system_accounting_auditd.rb
+++ b/controls/4_1_configure_system_accounting_auditd.rb
@@ -22,6 +22,7 @@ cis_level = input('cis_level')
 title '4.1 Configure System Accounting (auditd)'
 
 uid_min = login_defs.UID_MIN.to_i
+uname_machine = command('uname -m').stdout.strip
 
 control 'cis-dil-benchmark-4.1.1.1' do
   title 'Ensure audit log storage size is configured'
@@ -150,8 +151,7 @@ control 'cis-dil-benchmark-4.1.5' do
     its('content') { should match %r{^-w /etc/localtime -p wa -k time-change$} }
   end
 
-  uname = command('uname -m').stdout.strip
-  if uname == 'x86_64' || uname == 'aarch64'
+  if uname_machine == 'x86_64' || uname_machine == 'aarch64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S adjtimex -S settimeofday -k time-change$/) }
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S clock_settime -k time-change$/) }
@@ -196,8 +196,7 @@ control 'cis-dil-benchmark-4.1.7' do
     its('content') { should match %r{^-w /etc/sysconfig/network -p wa -k system-locale$} }
   end
 
-  uname = command('uname -m').stdout.strip
-  if uname == 'x86_64' || uname == 'aarch64'
+  if uname_machine == 'x86_64' || uname_machine == 'aarch64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S sethostname -S setdomainname -k system-locale$/) }
     end
@@ -276,8 +275,7 @@ control 'cis-dil-benchmark-4.1.11' do
     its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=#{uid_min} -F auid!=4294967295 -k perm_mod$/) }
   end
 
-  uname = command('uname -m').stdout.strip
-  if uname == 'x86_64'
+  if uname_machine == 'x86_64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=#{uid_min} -F auid!=4294967295 -k perm_mod$/) }
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=#{uid_min} -F auid!=4294967295 -k perm_mod$/) }
@@ -286,7 +284,7 @@ control 'cis-dil-benchmark-4.1.11' do
   end
 
   # For aarch64 the symbols chmod, chown and lchown are not available
-  if uname == 'aarch64'
+  if uname_machine == 'aarch64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S fchmod -S fchmodat -F auid>=#{uid_min} -F auid!=4294967295 -k perm_mod$/) }
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S fchown -S fchownat -F auid>=#{uid_min} -F auid!=4294967295 -k perm_mod$/) }
@@ -310,8 +308,7 @@ control 'cis-dil-benchmark-4.1.12' do
     its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=#{uid_min} -F auid!=4294967295 -k access$/) }
   end
 
-  uname = command('uname -m').stdout.strip
-  if uname == 'x86_64'
+  if uname_machine == 'x86_64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=#{uid_min} -F auid!=4294967295 -k access$/) }
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=#{uid_min} -F auid!=4294967295 -k access$/) }
@@ -319,7 +316,7 @@ control 'cis-dil-benchmark-4.1.12' do
   end
 
   # For aarch64 the symbols creat and open are not available
-  if uname == 'aarch64'
+  if uname_machine == 'aarch64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=#{uid_min} -F auid!=4294967295 -k access$/) }
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=#{uid_min} -F auid!=4294967295 -k access$/) }
@@ -358,8 +355,7 @@ control 'cis-dil-benchmark-4.1.14' do
     its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S mount -F auid>=#{uid_min} -F auid!=4294967295 -k mounts$/) }
   end
 
-  uname = command('uname -m').stdout.strip
-  if uname == 'x86_64' || uname == 'aarch64'
+  if uname_machine == 'x86_64' || uname_machine == 'aarch64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S mount -F auid>=#{uid_min} -F auid!=4294967295 -k mounts$/) }
     end
@@ -380,15 +376,14 @@ control 'cis-dil-benchmark-4.1.15' do
     its('content') { should match(/^-a (always,exit|exit,always) -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=#{uid_min} -F auid!=4294967295 -k delete$/) }
   end
 
-  uname = command('uname -m').stdout.strip
-  if uname == 'x86_64'
+  if uname_machine == 'x86_64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=#{uid_min} -F auid!=4294967295 -k delete$/) }
     end
   end
 
   # For aarch64 the symbols unlink and rename are not available
-  if uname == 'aarch64'
+  if uname_machine == 'aarch64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S unlinkat -S renameat -F auid>=#{uid_min} -F auid!=4294967295 -k delete$/) }
     end
@@ -442,8 +437,7 @@ control 'cis-dil-benchmark-4.1.18' do
     its('content') { should match(%r{^-w /sbin/modprobe -p x -k modules$}) }
   end
 
-  uname = command('uname -m').stdout.strip
-  if uname == 'x86_64' || uname == 'aarch64'
+  if uname_machine == 'x86_64' || uname_machine == 'aarch64'
     describe file('/etc/audit/audit.rules') do
       its('content') { should match(/^-a (always,exit|exit,always) -F arch=b64 -S init_module -S delete_module -k modules$/) }
     end


### PR DESCRIPTION
The command `uname -m` is executed multiple times, and it would be nicer to move it to a global variable for reuse. At the same time, we should rename the variable to a better name.