### PR TITLE
3-5 Fix loopback address match

### DIFF
--- a/controls/3_5_firewall_configuration.rb
+++ b/controls/3_5_firewall_configuration.rb
@@ -117,7 +117,7 @@ control 'cis-dil-benchmark-3.5.1.4' do
   tag cis: 'distribution-independent-linux:3.5.1.4'
   tag level: 1
 
-  port.where { address !~ /^(127\.|::1)$/ }.ports.each do |port|
+  port.where { address !~ /^(127\.[0-9]+\.[0-9]+\.[0-9]+|::1)$/ }.ports.each do |port|
     describe "Firewall rule should exist for port #{port}" do
       subject { ip6tables.retrieve_rules.any? { |s| s =~ /\s--(dport|dports) #{port}\s/ } }
       it { should be true }
@@ -214,7 +214,7 @@ control 'cis-dil-benchmark-3.5.2.4' do
   tag cis: 'distribution-independent-linux:3.5.2.4'
   tag level: 1
 
-  port.where { address !~ /^(127\.|::1)$/ }.ports.each do |port|
+  port.where { address !~ /^(127\.[0-9]+\.[0-9]+\.[0-9]+|::1)$/ }.ports.each do |port|
     describe "Firewall rule should exist for port #{port}" do
       subject { iptables.retrieve_rules.any? { |s| s =~ /\s--(dport|dports) #{port}\s/ } }
       it { should be true }


### PR DESCRIPTION
Fix regression introduced since ad539693ae1d5c8c038c76c1accee5fbc22308fd, in this CIS checks 3.5.1.4 and 3.5.2.4 were updated to filter open ports with address `127.0.0.1` to `127.` which never matches.

Update filtering to check for a full IPv4 address corresponding to CIDR 127.0.0.0/8